### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -12,16 +12,37 @@ const fetchWakatimeStats = async ({ username, api_domain }) => {
     throw new MissingParamError(["username"]);
   }
 
+  // Allow-list of permitted WakaTime API domains
+  const ALLOWED_API_DOMAINS = ["wakatime.com", "wakatime.dev"];
+
+  // Helper to sanitize and validate the api_domain
+  function getAllowedApiDomain(domain) {
+    if (!domain) return "wakatime.com";
+    // Remove protocol, port, and path, only keep hostname
+    try {
+      // If domain includes protocol, use URL to parse, else prepend protocol for parsing
+      const url = domain.match(/^https?:\/\//)
+        ? new URL(domain)
+        : new URL("https://" + domain);
+      const hostname = url.hostname.replace(/\/$/gi, "");
+      if (ALLOWED_API_DOMAINS.includes(hostname)) {
+        return hostname;
+      }
+    } catch (e) {
+      // If parsing fails, fall through to default
+    }
+    return "wakatime.com";
+  }
+
   try {
+    const safeApiDomain = getAllowedApiDomain(api_domain);
     const { data } = await axios.get(
-      `https://${
-        api_domain ? api_domain.replace(/\/$/gi, "") : "wakatime.com"
-      }/api/v1/users/${username}/stats?is_including_today=true`,
+      `https://${safeApiDomain}/api/v1/users/${encodeURIComponent(username)}/stats?is_including_today=true`,
     );
 
     return data.data;
   } catch (err) {
-    if (err.response.status < 200 || err.response.status > 299) {
+    if (err.response && (err.response.status < 200 || err.response.status > 299)) {
       throw new CustomError(
         `Could not resolve to a User with the login of '${username}'`,
         "WAKATIME_USER_NOT_FOUND",


### PR DESCRIPTION
Potential fix for [https://github.com/TheMasterCoders/github-stats-and-stuff-i-guess/security/code-scanning/1](https://github.com/TheMasterCoders/github-stats-and-stuff-i-guess/security/code-scanning/1)

To fix the SSRF vulnerability, we must ensure that the `api_domain` parameter cannot be used to make requests to arbitrary domains. The best approach is to maintain an allow-list of permitted domains (e.g., only "wakatime.com" and perhaps "wakatime.dev" for testing), and only use the user-provided `api_domain` if it matches an entry in this allow-list. Otherwise, default to "wakatime.com". This change should be made in `src/fetchers/wakatime-fetcher.js`, specifically in the construction of the URL for the axios request. We should also sanitize the `api_domain` to remove any protocol, path, or port information, and only allow valid hostnames.

**Required changes:**
- Add an allow-list of permitted domains in `src/fetchers/wakatime-fetcher.js`.
- Before using `api_domain`, check if it matches an entry in the allow-list.
- If not, default to "wakatime.com".
- Optionally, strip any protocol or path from `api_domain` to ensure only the hostname is used.

No changes are needed in `api/wakatime.js` since the fix is best applied at the fetcher level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
